### PR TITLE
Add batch delete for DeleteCommand

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_RANGE = "The range provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -26,11 +26,22 @@ public class DeleteCommand extends Command {
     private final Index targetIndex;
     private final Index endIndex;
 
+    /**
+     * Creates a DeleteCommand to delete the person at specified index
+     *
+     * @param targetIndex the person to be deleted
+     */
     public DeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
         endIndex = targetIndex;
     }
 
+    /**
+     * Creates a DeleteCommand to delete the persons between the specified indexes.
+     *
+     * @param targetIndex the first person to be deleted
+     * @param endIndex the last person to be deleted
+     */
     public DeleteCommand(Index targetIndex, Index endIndex) {
         this.targetIndex = targetIndex;
         this.endIndex = endIndex;

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -18,7 +18,7 @@ public class DeleteCommand extends Command {
     public static final String MESSAGE_USAGE =
             "delete: Deletes the person identified by the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: delete 1";
+            + "Example: delete 1 or delete 1-3";
 
     public static final String MESSAGE_NUMBER_DELETED_PERSON = "%d Deleted Persons: \n";
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "%1$s \n";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -66,6 +66,7 @@ public class DeleteCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
+                && targetIndex.equals(((DeleteCommand) other).targetIndex)
+                && endIndex.equals(((DeleteCommand) other).endIndex)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -18,9 +18,9 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            if (args.contains(",")) {
-                Index start = ParserUtil.parseIndex(args.substring(1, args.indexOf(",")));
-                Index end = ParserUtil.parseIndex(args.substring(args.indexOf(",") + 1));
+            if (args.contains("-")) {
+                Index start = ParserUtil.parseIndex(args.substring(1, args.indexOf("-")));
+                Index end = ParserUtil.parseIndex(args.substring(args.indexOf("-") + 1));
                 return new DeleteCommand(start, end);
             } else {
                 Index index = ParserUtil.parseIndex(args);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -18,8 +18,14 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            if (args.contains(",")) {
+                Index start = ParserUtil.parseIndex(args.substring(1, args.indexOf(",")));
+                Index end = ParserUtil.parseIndex(args.substring(args.indexOf(",") + 1));
+                return new DeleteCommand(start, end);
+            } else {
+                Index index = ParserUtil.parseIndex(args);
+                return new DeleteCommand(index);
+            }
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -137,6 +137,10 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered list to show only the persons at the given {@code targetIndex1} and
+     * {@code targetIndex2} in the {@code model}'s address book.
+     */
     public static void showPersonAtMultipleIndex(Model model, Index targetIndex1, Index targetIndex2) {
         assertTrue(targetIndex1.getZeroBased() < model.getFilteredPersonList().size());
         assertTrue(targetIndex2.getZeroBased() < model.getFilteredPersonList().size());

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -137,4 +137,18 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    public static void showPersonAtMultipleIndex(Model model, Index targetIndex1, Index targetIndex2) {
+        assertTrue(targetIndex1.getZeroBased() < model.getFilteredPersonList().size());
+        assertTrue(targetIndex2.getZeroBased() < model.getFilteredPersonList().size());
+
+        Person person1 = model.getFilteredPersonList().get(targetIndex1.getZeroBased());
+        Person person2 = model.getFilteredPersonList().get(targetIndex2.getZeroBased());
+        final String[] splitName1 = person1.getName().fullName.split("\\s+");
+        final String[] splitName2 = person2.getName().fullName.split("\\s+");
+
+        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName1[0], splitName2[0])));
+
+        assertEquals(2, model.getFilteredPersonList().size());
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtMultipleIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -28,15 +30,32 @@ public class DeleteCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
+        //Deletes 1 person
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        expectedMessage = String.format(DeleteCommand.MESSAGE_NUMBER_DELETED_PERSON, 1) + expectedMessage;
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+
+        //Deletes 2 persons
+        Person personToDelete1 = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete2 = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        DeleteCommand deleteCommand1 = new DeleteCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
+
+        String expectedMessage1 = String.format(DeleteCommand.MESSAGE_NUMBER_DELETED_PERSON, 2)
+                + String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete1)
+                + String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete2);
+
+        ModelManager expectedModel1 = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel1.deletePerson(personToDelete1);
+        expectedModel1.deletePerson(personToDelete2);
+
+        assertCommandSuccess(deleteCommand1, model, expectedMessage1, expectedModel1);
     }
 
     @Test
@@ -45,22 +64,51 @@ public class DeleteCommandTest {
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 
         assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+
+        Index invalidStartIndex = Index.fromOneBased(model.getFilteredPersonList().size() - 2);
+        Index invalidEndIndex = Index.fromOneBased(model.getFilteredPersonList().size() - 4);
+        DeleteCommand deleteCommand1 = new DeleteCommand(invalidStartIndex, invalidEndIndex);
+
+        assertCommandFailure(deleteCommand1, model, Messages.MESSAGE_INVALID_RANGE);
     }
 
     @Test
     public void execute_validIndexFilteredList_success() {
+        //Deletes 1 person in the filtered list
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        expectedMessage = String.format(DeleteCommand.MESSAGE_NUMBER_DELETED_PERSON, 1) + expectedMessage;
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
         showNoPerson(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validRangeFilteredList_success() {
+        //Deletes 2 person in the filtered list
+        showPersonAtMultipleIndex(model, INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
+
+        Person personToDelete1 = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person personToDelete2 = model.getFilteredPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
+        DeleteCommand deleteCommand1 = new DeleteCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
+
+        String expectedMessage1 = String.format(DeleteCommand.MESSAGE_NUMBER_DELETED_PERSON, 2)
+                + String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete1)
+                + String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete2);
+
+        ModelManager expectedModel1 = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel1.deletePerson(personToDelete1);
+        expectedModel1.deletePerson(personToDelete2);
+        showNoPerson(expectedModel1);
+
+        assertCommandSuccess(deleteCommand1, model, expectedMessage1, expectedModel1);
     }
 
     @Test
@@ -77,16 +125,37 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_invalidRangeFilteredList_throwsCommandException() {
+        showPersonAtMultipleIndex(model, INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
+
+        Index invalidStartIndex = INDEX_SECOND_PERSON;
+        Index invalidEndIndex = INDEX_THIRD_PERSON;
+        //ensures that the invalidStartIndex and invalidEndIndex are still in bound of the address book list
+        assertTrue(invalidStartIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+        assertTrue(invalidEndIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        DeleteCommand deleteCommand = new DeleteCommand(invalidStartIndex, invalidEndIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_RANGE);
+    }
+
+    @Test
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
         DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeleteCommand deleteBatchCommand1 = new DeleteCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
+        DeleteCommand deleteBatchCommand2 = new DeleteCommand(INDEX_FIRST_PERSON, INDEX_THIRD_PERSON);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+        assertTrue(deleteBatchCommand1.equals(deleteBatchCommand1));
 
         // same values -> returns true
         DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        DeleteCommand deleteBatchCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON);
+        assertTrue(deleteBatchCommand1.equals(deleteBatchCommandCopy));
 
         // different types -> returns false
         assertFalse(deleteFirstCommand.equals(1));
@@ -96,6 +165,8 @@ public class DeleteCommandTest {
 
         // different person -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+
+        assertFalse(deleteBatchCommand1.equals(deleteBatchCommand2));
     }
 
     /**


### PR DESCRIPTION
DeleteCommand can now allow deleting of multiple contacts. 
For example, "delete 2-4" deletes the 2, 3, 4 contact in the list.

Resolves #32 