### PR TITLE
Include newly added start and end time

### DIFF
--- a/src/main/java/seedu/address/logic/commands/modulelesson/EditModuleLessonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/modulelesson/EditModuleLessonCommand.java
@@ -95,10 +95,14 @@ public class EditModuleLessonCommand extends Command {
         ModuleCode updatedModuleCode = editLessonDescriptor.getModuleCode()
                 .orElse(moduleLessonToEdit.getModuleCode());
         LessonDay updatedLessonDay = editLessonDescriptor.getLessonDay().orElse(moduleLessonToEdit.getDay());
-        LessonTime updatedLessonTime = editLessonDescriptor.getLessonTime().orElse(moduleLessonToEdit.getTime());
+        LessonTime updatedLessonStartTime = editLessonDescriptor.getLessonStartTime()
+                .orElse(moduleLessonToEdit.getLessonStartTime());
+        LessonTime updatedLessonEndTime = editLessonDescriptor.getLessonEndTime()
+                .orElse(moduleLessonToEdit.getLessonEndTime());
         Remark updatedRemark = editLessonDescriptor.getRemark().orElse(moduleLessonToEdit.getRemark());
 
-        return new ModuleLesson(updatedModuleCode, updatedLessonDay, updatedLessonTime, updatedRemark);
+        return new ModuleLesson(updatedModuleCode, updatedLessonDay,
+                updatedLessonStartTime, updatedLessonEndTime, updatedRemark);
     }
 
     @Override
@@ -125,7 +129,8 @@ public class EditModuleLessonCommand extends Command {
     public static class EditLessonDescriptor {
         private ModuleCode code;
         private LessonDay day;
-        private LessonTime time;
+        private LessonTime startTime;
+        private LessonTime endTime;
         private Remark remark;
 
         public EditLessonDescriptor() {}
@@ -136,7 +141,8 @@ public class EditModuleLessonCommand extends Command {
         public EditLessonDescriptor(EditLessonDescriptor toCopy) {
             setModuleCode(toCopy.code);
             setLessonDay(toCopy.day);
-            setLessonTime(toCopy.time);
+            setLessonStartTime(toCopy.startTime);
+            setLessonEndTime(toCopy.endTime);
             setRemark(toCopy.remark);
         }
 
@@ -144,7 +150,7 @@ public class EditModuleLessonCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(code, day, time, remark);
+            return CollectionUtil.isAnyNonNull(code, day, startTime, endTime, remark);
         }
 
         public void setModuleCode(ModuleCode code) {
@@ -163,12 +169,20 @@ public class EditModuleLessonCommand extends Command {
             return Optional.ofNullable(day);
         }
 
-        public void setLessonTime(LessonTime time) {
-            this.time = time;
+        public void setLessonStartTime(LessonTime startTime) {
+            this.startTime = startTime;
         }
 
-        public Optional<LessonTime> getLessonTime() {
-            return Optional.ofNullable(time);
+        public Optional<LessonTime> getLessonStartTime() {
+            return Optional.ofNullable(startTime);
+        }
+
+        public void setLessonEndTime(LessonTime endTime) {
+            this.endTime = endTime;
+        }
+
+        public Optional<LessonTime> getLessonEndTime() {
+            return Optional.ofNullable(endTime);
         }
 
         public void setRemark(Remark remark) {
@@ -196,7 +210,8 @@ public class EditModuleLessonCommand extends Command {
 
             return getModuleCode().equals(e.getModuleCode())
                     && getLessonDay().equals(e.getLessonDay())
-                    && getLessonTime().equals(e.getLessonTime())
+                    && getLessonStartTime().equals(e.getLessonStartTime())
+                    && getLessonEndTime().equals(e.getLessonEndTime())
                     && getRemark().equals(e.getRemark());
         }
     }

--- a/src/main/java/seedu/address/logic/parser/modulelesson/EditModuleLessonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/modulelesson/EditModuleLessonCommandParser.java
@@ -81,8 +81,10 @@ public class EditModuleLessonCommandParser implements Parser<EditModuleLessonCom
         }
 
         if (validArgumentMultimap.getValue(PREFIX_LESSON_TIME).isPresent()) {
-            editLessonDescriptor.setLessonTime(
-                    ParserUtil.parseLessonTime(validArgumentMultimap.getValue(PREFIX_LESSON_TIME).get()));
+            editLessonDescriptor.setLessonStartTime(
+                    ParserUtil.parseLessonTime(validArgumentMultimap.getValue(PREFIX_LESSON_TIME).get()).get(0));
+            editLessonDescriptor.setLessonEndTime(
+                    ParserUtil.parseLessonTime(validArgumentMultimap.getValue(PREFIX_LESSON_TIME).get()).get(1));
         }
 
         if (validArgumentMultimap.getValue(PREFIX_REMARK).isPresent()) {

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -52,8 +52,8 @@ public class CommandTestUtil {
     public static final String VALID_MODULE_CODE_CS2040S_B05 = "CS2040S B05";
     public static final String VALID_LESSON_DAY_TUES = "2";
     public static final String VALID_LESSON_DAY_WED = "3";
-    public static final String VALID_LESSON_TIME_11 = "11:00";
-    public static final String VALID_LESSON_TIME_12 = "12:00";
+    public static final String VALID_LESSON_TIME_11_12 = "11:00 12:00";
+    public static final String VALID_LESSON_TIME_12_13 = "12:00 13:00";
     public static final String VALID_MODULE_LESSON_REMARK = "COM1-130";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
@@ -70,8 +70,8 @@ public class CommandTestUtil {
     public static final String REMARK_DESC_BOB = " " + PREFIX_REMARK + VALID_REMARK_BOB;
     public static final String LESSON_DAY_DESC_TUES = " " + PREFIX_LESSON_DAY + VALID_LESSON_DAY_TUES;
     public static final String LESSON_DAY_DESC_WED = " " + PREFIX_LESSON_DAY + VALID_LESSON_DAY_WED;
-    public static final String LESSON_TIME_DESC_11 = " " + PREFIX_LESSON_TIME + VALID_LESSON_TIME_11;
-    public static final String LESSON_TIME_DESC_12 = " " + PREFIX_LESSON_TIME + VALID_LESSON_TIME_12;
+    public static final String LESSON_TIME_DESC_11_12 = " " + PREFIX_LESSON_TIME + VALID_LESSON_TIME_11_12;
+    public static final String LESSON_TIME_DESC_12_13 = " " + PREFIX_LESSON_TIME + VALID_LESSON_TIME_12_13;
     public static final String REMARK_DESC_MODULES = " " + PREFIX_REMARK + VALID_MODULE_LESSON_REMARK;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
@@ -102,9 +102,9 @@ public class CommandTestUtil {
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .build();
         DESC_CS2040S = new EditLessonDescriptorBuilder().withModuleCode(parseModuleCode(VALID_MODULE_CODE_CS2040S_B05))
-                .withLessonDay(new LessonDay("2")).withLessonTime(new LessonTime("10:00")).build();
+                .withLessonDay(new LessonDay("2")).withLessonStartTime(new LessonTime("10:00")).build();
         DESC_CS2030S = new EditLessonDescriptorBuilder().withModuleCode(parseModuleCode(VALID_MODULE_CODE_CS2030S_T12))
-                .withLessonDay(new LessonDay("5")).withLessonTime(new LessonTime("13:30")).build();
+                .withLessonDay(new LessonDay("5")).withLessonStartTime(new LessonTime("13:30")).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/modulelesson/EditLessonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/modulelesson/EditLessonDescriptorTest.java
@@ -43,7 +43,7 @@ public class EditLessonDescriptorTest {
 
         // different time -> returns false
         EditLessonDescriptor diffTimeDescriptor = new EditLessonDescriptorBuilder(DESC_CS2040S)
-                .withLessonTime(new LessonTime("08:00")).build();
+                .withLessonStartTime(new LessonTime("08:00")).build();
         assertFalse(descriptor.equals(diffTimeDescriptor));
 
         // different remark -> returns false

--- a/src/test/java/seedu/address/logic/commands/person/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/AddPersonCommandTest.java
@@ -162,12 +162,6 @@ public class AddPersonCommandTest {
         }
 
         @Override
-        public boolean hasModuleLesson(ModuleLesson moduleLesson) {
-            throw new AssertionError("This method should not be called.");
-
-        }
-
-        @Override
         public void setModuleLesson(ModuleLesson target, ModuleLesson editedLesson) {
             throw new AssertionError("This method should not be called");
         }

--- a/src/test/java/seedu/address/logic/parser/modulelesson/EditModuleLessonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/modulelesson/EditModuleLessonCommandParserTest.java
@@ -8,13 +8,13 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_MODULE_CODE_D
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_REMARK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LESSON_DAY_DESC_TUES;
 import static seedu.address.logic.commands.CommandTestUtil.LESSON_DAY_DESC_WED;
-import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_DESC_11;
+import static seedu.address.logic.commands.CommandTestUtil.LESSON_TIME_DESC_11_12;
 import static seedu.address.logic.commands.CommandTestUtil.MODULE_CODE_DESC_CS2030S_T12;
 import static seedu.address.logic.commands.CommandTestUtil.MODULE_CODE_DESC_CS2040;
 import static seedu.address.logic.commands.CommandTestUtil.REMARK_DESC_MODULES;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_DAY_TUES;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_DAY_WED;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_11;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LESSON_TIME_11_12;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_CS2030S_T12;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_CS2040S_B05;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_LESSON_REMARK;
@@ -22,6 +22,7 @@ import static seedu.address.logic.commands.modulelesson.EditModuleLessonCommand.
 import static seedu.address.logic.commands.modulelesson.EditModuleLessonCommand.MESSAGE_USAGE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.parseLessonTime;
 import static seedu.address.model.util.SampleDataUtil.parseModuleCode;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 
@@ -30,8 +31,9 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.modulelesson.EditModuleLessonCommand;
 import seedu.address.logic.commands.modulelesson.EditModuleLessonCommand.EditLessonDescriptor;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.modulelesson.LessonDay;
-import seedu.address.model.modulelesson.LessonTime;
 import seedu.address.model.person.ModuleCode;
 import seedu.address.model.person.Remark;
 import seedu.address.testutil.EditLessonDescriptorBuilder;
@@ -76,7 +78,7 @@ public class EditModuleLessonCommandParserTest {
     public void parse_invalidValue_failure() {
         assertParseFailure(p, "1" + INVALID_MODULE_CODE_DESC, ModuleCode.MESSAGE_CONSTRAINTS);
         assertParseFailure(p, "1" + INVALID_LESSON_DAY_DESC, LessonDay.MESSAGE_CONSTRAINTS);
-        assertParseFailure(p, "1" + INVALID_LESSON_TIME_DESC, LessonTime.MESSAGE_CONSTRAINTS);
+        assertParseFailure(p, "1" + INVALID_LESSON_TIME_DESC, ParserUtil.MESSAGE_INVALID_LESSON_DURATION);
         assertParseFailure(p, "1" + INVALID_REMARK_DESC, Remark.MESSAGE_CONSTRAINTS);
 
         // invalid module code followed by valid day
@@ -94,18 +96,19 @@ public class EditModuleLessonCommandParserTest {
     }
 
     @Test
-    public void parse_allFieldsSpecified_success() {
+    public void parse_allFieldsSpecified_success() throws ParseException {
         Index targetIndex = INDEX_FIRST;
         StringBuilder sb = new StringBuilder(targetIndex.getOneBased() + "");
         sb.append(MODULE_CODE_DESC_CS2030S_T12)
                 .append(LESSON_DAY_DESC_TUES)
-                .append(LESSON_TIME_DESC_11)
+                .append(LESSON_TIME_DESC_11_12)
                 .append(REMARK_DESC_MODULES);
 
         EditLessonDescriptor descriptor = new EditLessonDescriptorBuilder()
                 .withModuleCode(parseModuleCode(VALID_MODULE_CODE_CS2030S_T12))
                 .withLessonDay(new LessonDay(VALID_LESSON_DAY_TUES))
-                .withLessonTime(new LessonTime(VALID_LESSON_TIME_11))
+                .withLessonStartTime(parseLessonTime(VALID_LESSON_TIME_11_12).get(0))
+                .withLessonEndTime(parseLessonTime(VALID_LESSON_TIME_11_12).get(1))
                 .withRemark(new Remark(VALID_MODULE_LESSON_REMARK)).build();
         EditModuleLessonCommand expectedCommand = new EditModuleLessonCommand(targetIndex, descriptor);
 
@@ -128,7 +131,7 @@ public class EditModuleLessonCommandParserTest {
     }
 
     @Test
-    public void parse_oneFieldSpecified_success() {
+    public void parse_oneFieldSpecified_success() throws ParseException {
         Index targetIndex = INDEX_FIRST;
         String arg = targetIndex.getOneBased() + "";
         EditLessonDescriptor descriptor;
@@ -148,24 +151,26 @@ public class EditModuleLessonCommandParserTest {
 
         // time
         descriptor = new EditLessonDescriptorBuilder()
-                .withLessonTime(new LessonTime(VALID_LESSON_TIME_11)).build();
+                .withLessonStartTime(parseLessonTime(VALID_LESSON_TIME_11_12).get(0))
+                .withLessonEndTime(parseLessonTime(VALID_LESSON_TIME_11_12).get(1)).build();
         expectedCommand = new EditModuleLessonCommand(targetIndex, descriptor);
-        assertParseSuccess(p, arg + LESSON_TIME_DESC_11, expectedCommand);
+        assertParseSuccess(p, arg + LESSON_TIME_DESC_11_12, expectedCommand);
     }
 
     @Test
-    public void parse_multipleRepeatedFields_acceptsLast() {
+    public void parse_multipleRepeatedFields_acceptsLast() throws ParseException {
         Index ind = INDEX_FIRST;
         StringBuilder sb = new StringBuilder(ind.getOneBased() + "");
         sb.append(MODULE_CODE_DESC_CS2030S_T12).append(LESSON_DAY_DESC_TUES)
                 .append(MODULE_CODE_DESC_CS2040).append(LESSON_DAY_DESC_TUES)
                 .append(MODULE_CODE_DESC_CS2030S_T12).append(LESSON_DAY_DESC_WED)
-                .append(LESSON_TIME_DESC_11).append(REMARK_DESC_MODULES);
+                .append(LESSON_TIME_DESC_11_12).append(REMARK_DESC_MODULES);
 
         EditLessonDescriptor descriptor = new EditLessonDescriptorBuilder()
                 .withModuleCode(parseModuleCode(VALID_MODULE_CODE_CS2030S_T12))
                 .withLessonDay(new LessonDay(VALID_LESSON_DAY_WED))
-                .withLessonTime(new LessonTime(VALID_LESSON_TIME_11))
+                .withLessonStartTime(parseLessonTime(VALID_LESSON_TIME_11_12).get(0))
+                .withLessonEndTime(parseLessonTime(VALID_LESSON_TIME_11_12).get(1))
                 .withRemark(new Remark(VALID_MODULE_LESSON_REMARK)).build();
         EditModuleLessonCommand expectedCommand = new EditModuleLessonCommand(ind, descriptor);
 
@@ -173,7 +178,7 @@ public class EditModuleLessonCommandParserTest {
     }
 
     @Test
-    public void parse_invalidValueFollowedByValidValue_success() {
+    public void parse_invalidValueFollowedByValidValue_success() throws ParseException {
         Index ind = INDEX_FIRST;
         String arg = ind.getOneBased() + "";
         EditLessonDescriptor descriptor;
@@ -186,9 +191,10 @@ public class EditModuleLessonCommandParserTest {
 
         // other valid values specified
         descriptor = new EditLessonDescriptorBuilder().withLessonDay(new LessonDay(VALID_LESSON_DAY_WED))
-                .withLessonTime(new LessonTime(VALID_LESSON_TIME_11)).build();
+                .withLessonStartTime(parseLessonTime(VALID_LESSON_TIME_11_12).get(0))
+                .withLessonEndTime(parseLessonTime(VALID_LESSON_TIME_11_12).get(1)).build();
         expectedCommand = new EditModuleLessonCommand(ind, descriptor);
-        assertParseSuccess(p, arg + LESSON_TIME_DESC_11 + INVALID_LESSON_DAY_DESC + LESSON_DAY_DESC_WED,
+        assertParseSuccess(p, arg + LESSON_TIME_DESC_11_12 + INVALID_LESSON_DAY_DESC + LESSON_DAY_DESC_WED,
                 expectedCommand);
     }
 }

--- a/src/test/java/seedu/address/model/modulelesson/ModuleLessonTest.java
+++ b/src/test/java/seedu/address/model/modulelesson/ModuleLessonTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalModuleLessons.CS2100_LAB1;
-import static seedu.address.testutil.TypicalModuleLessons.CS2100_TUT1;
 import static seedu.address.testutil.TypicalModuleLessons.CS2103_TUT1;
 import static seedu.address.testutil.TypicalModuleLessons.CS2106_TUT1;
 
@@ -50,8 +49,8 @@ public class ModuleLessonTest {
         assertEquals(CS2100_LAB1.toString(),
                 "Module: CS2100 B31; Day: Tuesday; Start time: 15:00; End time: 16:00; Remark: COM1 0113");
 
-        assertEquals(CS2100_TUT1.toString(),
-                "Module: CS2100 T18; Day: Wednesday; Start time: 17:00; End time: 19:00; "
+        assertEquals(CS2106_TUT1.toString(),
+                "Module: CS2106 T18; Day: Wednesday; Start time: 17:00; End time: 19:00; "
                 + "Remark: COM1 01-20");
     }
 

--- a/src/test/java/seedu/address/testutil/EditLessonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditLessonDescriptorBuilder.java
@@ -29,7 +29,8 @@ public class EditLessonDescriptorBuilder {
         descriptor = new EditLessonDescriptor();
         descriptor.setModuleCode(lesson.getModuleCode());
         descriptor.setLessonDay(lesson.getDay());
-        descriptor.setLessonTime(lesson.getTime());
+        descriptor.setLessonStartTime(lesson.getLessonStartTime());
+        descriptor.setLessonEndTime(lesson.getLessonEndTime());
         descriptor.setRemark(lesson.getRemark());
     }
 
@@ -52,8 +53,16 @@ public class EditLessonDescriptorBuilder {
     /**
      * Sets the {@code LessonTime} of the {@code EditLessonDescriptor} that we are building.
      */
-    public EditLessonDescriptorBuilder withLessonTime(LessonTime time) {
-        descriptor.setLessonTime(time);
+    public EditLessonDescriptorBuilder withLessonStartTime(LessonTime startTime) {
+        descriptor.setLessonStartTime(startTime);
+        return this;
+    }
+
+    /**
+     * Sets the {@code LessonTime} of the {@code EditLessonDescriptor} that we are building.
+     */
+    public EditLessonDescriptorBuilder withLessonEndTime(LessonTime endTime) {
+        descriptor.setLessonEndTime(endTime);
         return this;
     }
 


### PR DESCRIPTION
I suggest shifting the message from parser util into lesson time, makes more sense to me to be there. ParserUtil should just call like LessonTime.MESSAGE_CONSTRAINT or smth, can follow 
![image](https://user-images.githubusercontent.com/68769529/138555736-95af2741-7718-411f-8ace-31801b07eddf.png)


Also, should considering split the message up into 2 different messages? A bit confusing when I just tested `ec 1 t/10:00 10:00` then it says missing compulsory start and end time
![image](https://user-images.githubusercontent.com/68769529/138555706-89b01d88-6c99-49a8-b932-23c2902fa7c3.png)

and idk who doing this but add a space or a dash between the start and end time ?
![image](https://user-images.githubusercontent.com/68769529/138555680-3249986b-7813-4f36-9769-c6771db3e412.png)

@tanruiquan 
