### PR TITLE
Fix bug in find person feature

### DIFF
--- a/src/main/java/seedu/address/logic/parser/person/FindPersonCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/person/FindPersonCommandParser.java
@@ -82,7 +82,6 @@ public class FindPersonCommandParser implements Parser<FindPersonCommand> {
         }
 
         List<String> moduleKeywordsList = Arrays.stream(modules.split("\\s+"))
-                .map(module -> '[' + module + ']')
                 .collect(Collectors.toList());
 
         return new FindPersonCommand(new ModuleCodesContainsKeywordsPredicate(moduleKeywordsList));

--- a/src/main/java/seedu/address/model/person/ModuleCodesContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/ModuleCodesContainsKeywordsPredicate.java
@@ -20,7 +20,7 @@ public class ModuleCodesContainsKeywordsPredicate implements Predicate<Person> {
         return keywords.stream()
                 .allMatch(keyword -> person.getModuleCodes()
                         .stream().anyMatch(moduleCode ->
-                                StringUtil.containsWordIgnoreCase(keyword, moduleCode.value)
+                                StringUtil.containsWordIgnoreCase(moduleCode.value, keyword)
                         )
                 );
     }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -18,7 +18,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .allMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -28,6 +28,8 @@ import seedu.address.model.modulelesson.LessonDay;
 import seedu.address.model.modulelesson.LessonTime;
 import seedu.address.model.modulelesson.ModuleCodeContainsKeywordsPredicate;
 import seedu.address.model.modulelesson.ModuleLesson;
+import seedu.address.model.person.ModuleCode;
+import seedu.address.model.person.ModuleCodesContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditLessonDescriptorBuilder;
@@ -182,21 +184,15 @@ public class CommandTestUtil {
     }
 
     /**
-     * Updates {@code model}'s filtered person list to show only the persons at the given {@code targetIndex1} and
-     * {@code targetIndex2} in the {@code model}'s address book.
+     * Updates {@code model}'s filtered person list to show only the persons that have the {@moduleCode} in the
+     * {@code model}'s address book.
      */
-    public static void showPersonAtMultipleIndex(Model model, Index targetIndex1, Index targetIndex2) {
-        assertTrue(targetIndex1.getZeroBased() < model.getFilteredPersonList().size());
-        assertTrue(targetIndex2.getZeroBased() < model.getFilteredPersonList().size());
+    public static void showPersonsWithModuleCode(Model model, ModuleCode moduleCode) {
+        List<String> moduleCodeToShow = new ArrayList<>();
+        moduleCodeToShow.add(moduleCode.getModuleCodeName());
+        ModuleCodesContainsKeywordsPredicate predicate = new ModuleCodesContainsKeywordsPredicate(moduleCodeToShow);
 
-        Person person1 = model.getFilteredPersonList().get(targetIndex1.getZeroBased());
-        Person person2 = model.getFilteredPersonList().get(targetIndex2.getZeroBased());
-        final String[] splitName1 = person1.getName().fullName.split("\\s+");
-        final String[] splitName2 = person2.getName().fullName.split("\\s+");
-
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName1[0], splitName2[0])));
-
-        assertEquals(2, model.getFilteredPersonList().size());
+        model.updateFilteredPersonList(predicate);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
@@ -7,7 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_MODULE_CODE_CS2
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.logic.commands.CommandTestUtil.showPersonAtMultipleIndex;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonsWithModuleCode;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.testutil.TypicalIndexes.INDEX_HENRY;
 import static seedu.address.testutil.TypicalIndexes.INDEX_ISAAC;
@@ -217,7 +217,8 @@ public class DeletePersonCommandTest {
     @Test
     public void execute_validRangeFilteredList_success() {
         //Deletes 2 person in the filtered list
-        showPersonAtMultipleIndex(model, INDEX_FIRST, INDEX_SECOND);
+        showPersonsWithModuleCode(model, new ModuleCode(VALID_MODULE_CODE_CS2100, new HashSet<>()));
+        assert model.getFilteredPersonList().size() == 2; //Only 2 persons in TypicalPersonList has CS2100
 
         Person personToDelete1 = model.getFilteredPersonList().get(INDEX_FIRST.getZeroBased());
         Person personToDelete2 = model.getFilteredPersonList().get(INDEX_SECOND.getZeroBased());
@@ -237,7 +238,9 @@ public class DeletePersonCommandTest {
     @Test
     public void execute_validModuleCodeFilteredList_success() {
         //Deletes 0 persons in filtered list, only deletes module code
-        showPersonAtMultipleIndex(model, INDEX_FIRST, INDEX_ISAAC);
+        showPersonsWithModuleCode(model, new ModuleCode(VALID_MODULE_CODE_CS2100, new HashSet<>()));
+        assert model.getFilteredPersonList().size() == 2; //Only 2 persons in TypicalPersonList has CS2100
+
         Person person = model.getFilteredPersonList().get(INDEX_SECOND.getZeroBased());
         Person newPerson = new PersonBuilder(person).withModuleCodes(VALID_MODULE_CODE_CS2100).build();
 
@@ -272,7 +275,8 @@ public class DeletePersonCommandTest {
 
     @Test
     public void execute_invalidRangeFilteredList_throwsCommandException() {
-        showPersonAtMultipleIndex(model, INDEX_FIRST, INDEX_SECOND);
+        showPersonsWithModuleCode(model, new ModuleCode(VALID_MODULE_CODE_CS2100, new HashSet<>()));
+        assert model.getFilteredPersonList().size() == 2; //Only 2 persons in TypicalPersonList has CS2100
 
         Index invalidStartIndex = INDEX_SECOND;
         Index invalidEndIndex = INDEX_THIRD;

--- a/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
@@ -80,7 +80,7 @@ public class DeletePersonCommandTest {
         Person newPerson2 = new PersonBuilder(person2).withModuleCodes(VALID_MODULE_CODE_CS2106).build();
 
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("[%s]", VALID_MODULE_CODE_CS2100))),
+                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2100))),
                 new ModuleCode(VALID_MODULE_CODE_CS2100, new HashSet<>()));
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_NUMBER_DELETED_PERSON, 1)
@@ -102,7 +102,7 @@ public class DeletePersonCommandTest {
         Set<LessonCode> lessonCodeToDelete = new HashSet<>();
         lessonCodeToDelete.add(new LessonCode("T12"));
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("[%s]", VALID_MODULE_CODE_CS2100 + " T12"))),
+                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2100 + " T12"))),
                 new ModuleCode(VALID_MODULE_CODE_CS2100, lessonCodeToDelete));
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_NUMBER_DELETED_PERSON, 1)
@@ -123,7 +123,7 @@ public class DeletePersonCommandTest {
         Set<LessonCode> lessonCodeToDelete = new HashSet<>();
         lessonCodeToDelete.add(new LessonCode("T12"));
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("[%s]", VALID_MODULE_CODE_CS2106 + " T12"))),
+                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2106 + " T12"))),
                 new ModuleCode(VALID_MODULE_CODE_CS2106, lessonCodeToDelete));
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_NUMBER_DELETED_PERSON, 0)
@@ -145,7 +145,7 @@ public class DeletePersonCommandTest {
         Set<LessonCode> lessonCodeToDelete = new HashSet<>();
         lessonCodeToDelete.add(new LessonCode("L08"));
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("[%s]", VALID_MODULE_CODE_CS2100 + " L08"))),
+                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2100 + " L08"))),
                 new ModuleCode(VALID_MODULE_CODE_CS2100, lessonCodeToDelete));
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_NUMBER_DELETED_PERSON, 0)
@@ -188,7 +188,7 @@ public class DeletePersonCommandTest {
     @Test
     public void execute_invalidMultipleModuleCodeUnfilteredList_throwsCommandException() {
         ModuleCodesContainsKeywordsPredicate predicate = new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("[CS2040S CS2030S]")));
+                Arrays.asList(String.format("CS2040S CS2030S")));
         Set<LessonCode> lessonCodeSet = new HashSet<>();
         lessonCodeSet.add(new LessonCode("CS2030S"));
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(predicate,
@@ -200,7 +200,7 @@ public class DeletePersonCommandTest {
     @Test
     public void execute_invalidLessonCodeUnfilteredList_throwsCommandException() {
         ModuleCodesContainsKeywordsPredicate predicate = new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("[CS2030S T1]")));
+                Arrays.asList(String.format("CS2030S T1")));
         Set<LessonCode> lessonCodeSet = new HashSet<>();
         lessonCodeSet.add(new LessonCode("T1"));
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(predicate,
@@ -254,7 +254,7 @@ public class DeletePersonCommandTest {
         Person newPerson = new PersonBuilder(person).withModuleCodes(VALID_MODULE_CODE_CS2100).build();
 
         ModuleCodesContainsKeywordsPredicate predicate = new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("[%s]", VALID_MODULE_CODE_CS2106)));
+                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2106)));
 
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(predicate,
                 new ModuleCode(VALID_MODULE_CODE_CS2106, new HashSet<>()));

--- a/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/DeletePersonCommandTest.java
@@ -102,7 +102,7 @@ public class DeletePersonCommandTest {
         Set<LessonCode> lessonCodeToDelete = new HashSet<>();
         lessonCodeToDelete.add(new LessonCode("T12"));
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2100 + " T12"))),
+                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2100))),
                 new ModuleCode(VALID_MODULE_CODE_CS2100, lessonCodeToDelete));
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_NUMBER_DELETED_PERSON, 1)
@@ -123,7 +123,7 @@ public class DeletePersonCommandTest {
         Set<LessonCode> lessonCodeToDelete = new HashSet<>();
         lessonCodeToDelete.add(new LessonCode("T12"));
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2106 + " T12"))),
+                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2106))),
                 new ModuleCode(VALID_MODULE_CODE_CS2106, lessonCodeToDelete));
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_NUMBER_DELETED_PERSON, 0)
@@ -145,7 +145,7 @@ public class DeletePersonCommandTest {
         Set<LessonCode> lessonCodeToDelete = new HashSet<>();
         lessonCodeToDelete.add(new LessonCode("L08"));
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2100 + " L08"))),
+                Arrays.asList(String.format("%s", VALID_MODULE_CODE_CS2100))),
                 new ModuleCode(VALID_MODULE_CODE_CS2100, lessonCodeToDelete));
 
         String expectedMessage = String.format(DeletePersonCommand.MESSAGE_NUMBER_DELETED_PERSON, 0)
@@ -186,21 +186,9 @@ public class DeletePersonCommandTest {
     }
 
     @Test
-    public void execute_invalidMultipleModuleCodeUnfilteredList_throwsCommandException() {
-        ModuleCodesContainsKeywordsPredicate predicate = new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("CS2040S CS2030S")));
-        Set<LessonCode> lessonCodeSet = new HashSet<>();
-        lessonCodeSet.add(new LessonCode("CS2030S"));
-        DeletePersonCommand deletePersonCommand = new DeletePersonCommand(predicate,
-                new ModuleCode("CS2040S", lessonCodeSet));
-
-        assertCommandFailure(deletePersonCommand, model, DeletePersonCommand.MESSAGE_DELETE_BY_MODULE_USAGE);
-    }
-
-    @Test
     public void execute_invalidLessonCodeUnfilteredList_throwsCommandException() {
         ModuleCodesContainsKeywordsPredicate predicate = new ModuleCodesContainsKeywordsPredicate(
-                Arrays.asList(String.format("CS2030S T1")));
+                Arrays.asList(String.format("CS2030S")));
         Set<LessonCode> lessonCodeSet = new HashSet<>();
         lessonCodeSet.add(new LessonCode("T1"));
         DeletePersonCommand deletePersonCommand = new DeletePersonCommand(predicate,

--- a/src/test/java/seedu/address/logic/commands/person/FindPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/FindPersonCommandTest.java
@@ -86,29 +86,19 @@ public class FindPersonCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
+    public void execute_oneName_onePersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Elle");
         FindPersonCommand command = new FindPersonCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
-    }
-
-    @Test
-    public void execute_multipleNames_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
-        FindPersonCommand command = new FindPersonCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+        assertEquals(Arrays.asList(ELLE), model.getFilteredPersonList());
     }
 
     @Test
     public void execute_multipleModuleCodes_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate("CS2106 CS2100");
+        ModuleCodesContainsKeywordsPredicate predicate = prepareModulePredicate("CS2103T CS2040");
         FindPersonCommand command = new FindPersonCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/person/FindPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/person/FindPersonCommandTest.java
@@ -137,7 +137,6 @@ public class FindPersonCommandTest {
      */
     private ModuleCodesContainsKeywordsPredicate prepareModulePredicate(String userInput) {
         List<String> moduleKeywordsList = Arrays.stream(userInput.split("\\s+"))
-                .map(moduleName -> '[' + moduleName + ']')
                 .collect(Collectors.toList());
         return new ModuleCodesContainsKeywordsPredicate(moduleKeywordsList);
     }

--- a/src/test/java/seedu/address/logic/parser/person/FindPersonCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/person/FindPersonCommandParserTest.java
@@ -51,7 +51,7 @@ public class FindPersonCommandParserTest {
         FindPersonCommand expectedFindPersonCommand =
                 new FindPersonCommand(new ModuleCodesContainsKeywordsPredicate(
                         Arrays.asList(
-                                String.format("[%s]", VALID_MODULE_CODE_CS2040)
+                                String.format("%s", VALID_MODULE_CODE_CS2040)
                         )
                 ));
         String userInput = String.format(" m/%s", VALID_MODULE_CODE_CS2040);

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -48,9 +48,9 @@ public class NameContainsKeywordsPredicateTest {
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
-        // Only one matching keyword
+        // Only one matching keyword - should not match Alice Carol as only Carol matches
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
-        assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
@@ -59,9 +59,7 @@ public class NameContainsKeywordsPredicateTest {
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
-        // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
+        NameContainsKeywordsPredicate predicate;
 
         // Non-matching keyword
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));


### PR DESCRIPTION
If I have a contact with module CS2040, searching by module with keyword `CS2040S`
should not return that contact.

Fixed this behaviour by removing now obsolete `[MODULE_CODE]` string representation
of module codes, and checking whether `moduleCode.value` contains search keyword,
and not the other way round

To be clear, if I have the following contacts with the respective module codes:
* A: CS2040
* B: CS2030
* C: CS2030S

Searching:
* `find m/CS2040S` will return nothing
* `find m/CS2030` will return both B and C
* `find m/CS2030S` will only return B

Also, to better fit UG description, `find n/ce Y` should only return `Bernice Yu`, and not every contact that has the alphabet `Y`.
Similarly, `find n/Bob Carol` should not return an `Alice Carol`

Resolves #176, #179, #195, #172